### PR TITLE
bump build-in lib to 1.5.3

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -9,6 +9,8 @@ jobs:
     strategy:
       matrix:
         php:
+          - '8.5'
+          - '8.5-zts'
           - '8.4'
           - '8.4-zts'
           - '8.3'

--- a/config.m4
+++ b/config.m4
@@ -45,7 +45,7 @@ if test "$PHP_BZIP3" != "no"; then
     PHP_EVAL_INCLINE($LIBBZIP3_CFLAGS)
   else
     dnl build-in library
-    LIBBZIP3_VERSON=1.5.2
+    LIBBZIP3_VERSON=1.5.3
     AC_MSG_RESULT(use build-in version $LIBBZIP3_VERSON)
 
     BZIP3_SOURCES="


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added PHP 8.5 and 8.5-zts to the testing matrix in continuous integration workflows
  * Updated bundled libbzip3 library from version 1.5.2 to 1.5.3
  * Updated library submodule to latest commit

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->